### PR TITLE
add iPad mini 2 (Wi-Fi) on 10.2

### DIFF
--- a/yalu102/offsets.c
+++ b/yalu102/offsets.c
@@ -48,6 +48,10 @@ void init_offsets() {
         allproc_offset = 0x5b20e0;
         procoff = 0x360; // iphone 5s, 10.2, @Slonick (github)
         rootvnode_offset = 0x5b20b8;
+    } else if (strcmp(u.version, "Darwin Kernel Version 16.3.0: Tue Nov 29 21:40:09 PST 2016; root:xnu-3789.32.1~4/RELEASE_ARM64_S5L8960X") == 0) {
+        allproc_offset = 0x5ac418;
+        procoff = 0x360; // ipad mini 2 (wifi), 10.2, @Defying (github)
+        rootvnode_offset = 0x5a8418;
     } else {
         printf("missing offset, prob crashing\n");
     }


### PR DESCRIPTION
should work, stops at `got a cpacr` due to lack of 4k device support so can't fully test atm