### PR TITLE
Logic refactor & URL Schemes / 3D Touch

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ Please use the "Issues" tab for **code related** issues only. If you need suppor
 
 | Device | Version | 
 |---------|----------|
+| iPhone 5S  | iOS 10.0.0 -> iOS 10.2 |
 | iPad Pro  | iOS 10.0.0 -> iOS 10.2 |
+| iPhone 6  | iOS 10.0.0 -> iOS 10.2 |
 | iPhone 6S  | iOS 10.0.0 -> iOS 10.2 |
 | iPhone SE  | iOS 10.0.0 -> iOS 10.2 |
 
@@ -20,10 +22,8 @@ In the near future, the jailbreak will support the following devices:
 
 | Device | Version | 
 |---------|----------|
-| iPhone 5S  | iOS 10.0.0 -> iOS 10.2 |
 | iPad Air| iOS 10.0.0 -> iOS 10.2 |
 | iPad Mini 2| iOS 10.0.0 -> iOS 10.2 |
-| iPhone 6  | iOS 10.0.0 -> iOS 10.2 |
 | iPad Air 2| iOS 10.0.0 -> iOS 10.2 |
 | iPad Mini 3| iOS 10.0.0 -> iOS 10.2 |
 | iPod touch (6G)  | iOS 10.0.0 -> iOS 10.2 |

--- a/README.md
+++ b/README.md
@@ -13,22 +13,22 @@ Please use the "Issues" tab for **code related** issues only. If you need suppor
 | iPhone 5S  | iOS 10.0.0 -> iOS 10.2 |
 | iPad Pro  | iOS 10.0.0 -> iOS 10.2 |
 | iPhone 6  | iOS 10.0.0 -> iOS 10.2 |
+| iPad Air| iOS 10.0.0 -> iOS 10.2 |
+| iPad Mini 2| iOS 10.0.0 -> iOS 10.2 |
+| iPad Mini 3| iOS 10.0.0 -> iOS 10.2 |
+| iPad Mini 4 | iOS 10.0.0 -> iOS 10.2 |
 | iPhone 6S  | iOS 10.0.0 -> iOS 10.2 |
 | iPhone SE  | iOS 10.0.0 -> iOS 10.2 |
+| iPod touch (6G)  | iOS 10.0.0 -> iOS 10.2 |
+| iPhone 7  | iOS 10.0.0 -> iOS 10.1.1 |
 
 ### Planned Support:
 
-In the near future, the jailbreak will support the following devices:
+In the near future, the jailbreak will support the following device:
 
 | Device | Version | 
 |---------|----------|
-| iPad Air| iOS 10.0.0 -> iOS 10.2 |
-| iPad Mini 2| iOS 10.0.0 -> iOS 10.2 |
 | iPad Air 2| iOS 10.0.0 -> iOS 10.2 |
-| iPad Mini 3| iOS 10.0.0 -> iOS 10.2 |
-| iPod touch (6G)  | iOS 10.0.0 -> iOS 10.2 |
-| iPad Mini 4 | iOS 10.0.0 -> iOS 10.2 |
-| iPhone 7  | iOS 10.0.0 -> iOS 10.1.1 |
 
 **Note, the iPhone 7 is only supported till iOS 10.1.1**
 If you are already on iOS 10.2 with an iPhone 7, **stay there**. The actual exploit behind this still works, but the KPP bypass does not.
@@ -54,7 +54,7 @@ If you are already on iOS 10.2 with an iPhone 7, **stay there**. The actual expl
 | Version | Download | SHA1 |
 |---------|----------|------|
 | Alpha  | [Link](https://yalu.qwertyoruiop.com/yalu102_alpha.ipa) | 2FE14F1C1E1A0D26203BBB123F6747A978DD2B4F  |
-
+| Beta Two | [Link](https://yalu.qwertyoruiop.com/yalu102_beta.ipa)| 4fddad7cca8aa0c0a6579c1d63d00917f15efc86 |
 ## Contributing
 
 Create a fork of the repository, make your changes and then create a pull request.

--- a/yalu102/AppDelegate.h
+++ b/yalu102/AppDelegate.h
@@ -11,7 +11,7 @@
 @interface AppDelegate : UIResponder <UIApplicationDelegate>
 
 @property (strong, nonatomic) UIWindow *window;
-
+@property (nonatomic) BOOL shouldJailbreak;
 
 @end
 

--- a/yalu102/AppDelegate.h
+++ b/yalu102/AppDelegate.h
@@ -11,7 +11,7 @@
 @interface AppDelegate : UIResponder <UIApplicationDelegate>
 
 @property (strong, nonatomic) UIWindow *window;
-@property (nonatomic) BOOL shouldJailbreak;
+@property (nonatomic, readwrite) BOOL shouldJailbreak;
 
 @end
 

--- a/yalu102/AppDelegate.m
+++ b/yalu102/AppDelegate.m
@@ -13,7 +13,7 @@
 @end
 
 @implementation AppDelegate
-
+@synthesize shouldJailbreak = _shouldJailbreak;
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
     // Override point for customization after application launch.

--- a/yalu102/AppDelegate.m
+++ b/yalu102/AppDelegate.m
@@ -25,6 +25,7 @@
     if ([urlParameter isEqual:@"break"]) {
         NSLog(@"We're breaking out of jail bois!");
         _shouldJailbreak = YES;
+        [[NSNotificationCenter defaultCenter] postNotificationName:@"ReevaluateShouldJailbreak" object:nil userInfo:nil];
     }
     return YES;
 }
@@ -33,7 +34,9 @@
     NSString *bundleIdentifier = [[NSBundle mainBundle] bundleIdentifier];
     NSLog(@"%@", shortcutItem.type);
     if ([shortcutItem.type isEqual:[NSString stringWithFormat: @"%@.BREAK", bundleIdentifier]]) {
+        NSLog(@"3D Touch action to jailbreak hit");
         _shouldJailbreak = YES;
+        [[NSNotificationCenter defaultCenter] postNotificationName: @"ReevaluateShouldJailbreak" object:nil userInfo:nil];
     }
 }
 

--- a/yalu102/AppDelegate.m
+++ b/yalu102/AppDelegate.m
@@ -25,9 +25,17 @@
     NSString *urlParameter = [url host];
     if ([urlParameter isEqual:@"break"]) {
         // URL scheme to jailbreak is being handled
-        NSLog(@"We're breaking out of jail bois!");
-        _shouldJailbreak = YES;
-        [[NSNotificationCenter defaultCenter] postNotificationName:@"ReevaluateShouldJailbreak" object:nil userInfo:nil];
+        UIAlertController *alertvc = [UIAlertController alertControllerWithTitle:@"Do you really want to jailbreak?" message:@"You used a URI scheme to break out of jail." preferredStyle:UIAlertControllerStyleAlert];
+        UIAlertAction *actionOk = [UIAlertAction actionWithTitle:@"I want to jailbreak!" style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
+            NSLog(@"We're breaking out of jail bois!");
+            _shouldJailbreak = YES;
+            [[NSNotificationCenter defaultCenter] postNotificationName:@"ReevaluateShouldJailbreak" object:nil userInfo:nil];
+        }];
+        UIAlertAction* cancelAction = [UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleDestructive handler:nil];
+        [alertvc addAction:actionOk];
+        [alertvc addAction:cancelAction];
+        UIViewController *vc = self.window.rootViewController;
+        [vc presentViewController:alertvc animated:YES completion:nil];
     }
     return YES;
 }

--- a/yalu102/AppDelegate.m
+++ b/yalu102/AppDelegate.m
@@ -20,6 +20,14 @@
     return YES;
 }
 
+- (BOOL)application:(UIApplication *)application handleOpenURL:(NSURL *)url {
+    NSString *urlParameter = [[url host] stringByReplacingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
+    if ([urlParameter isEqual:@"break"]) {
+        NSLog(@"We're breaking out of jail bois!");
+        _shouldJailbreak = YES;
+    }
+    return YES;
+}
 
 - (void)applicationWillResignActive:(UIApplication *)application {
     // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
@@ -46,6 +54,5 @@
 - (void)applicationWillTerminate:(UIApplication *)application {
     // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
 }
-
 
 @end

--- a/yalu102/AppDelegate.m
+++ b/yalu102/AppDelegate.m
@@ -21,12 +21,20 @@
 }
 
 - (BOOL)application:(UIApplication *)application handleOpenURL:(NSURL *)url {
-    NSString *urlParameter = [[url host] stringByReplacingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
+    NSString *urlParameter = [url host];
     if ([urlParameter isEqual:@"break"]) {
         NSLog(@"We're breaking out of jail bois!");
         _shouldJailbreak = YES;
     }
     return YES;
+}
+
+- (void)application:(UIApplication *)application performActionForShortcutItem:(UIApplicationShortcutItem *)shortcutItem completionHandler:(void (^)(BOOL))completionHandler {
+    NSString *bundleIdentifier = [[NSBundle mainBundle] bundleIdentifier];
+    NSLog(@"%@", shortcutItem.type);
+    if ([shortcutItem.type isEqual:[NSString stringWithFormat: @"%@.BREAK", bundleIdentifier]]) {
+        _shouldJailbreak = YES;
+    }
 }
 
 - (void)applicationWillResignActive:(UIApplication *)application {

--- a/yalu102/AppDelegate.m
+++ b/yalu102/AppDelegate.m
@@ -21,8 +21,10 @@
 }
 
 - (BOOL)application:(UIApplication *)application handleOpenURL:(NSURL *)url {
+    // URL scheme handling
     NSString *urlParameter = [url host];
     if ([urlParameter isEqual:@"break"]) {
+        // URL scheme to jailbreak is being handled
         NSLog(@"We're breaking out of jail bois!");
         _shouldJailbreak = YES;
         [[NSNotificationCenter defaultCenter] postNotificationName:@"ReevaluateShouldJailbreak" object:nil userInfo:nil];
@@ -31,10 +33,12 @@
 }
 
 - (void)application:(UIApplication *)application performActionForShortcutItem:(UIApplicationShortcutItem *)shortcutItem completionHandler:(void (^)(BOOL))completionHandler {
+    // 3D Touch shortcut action handling
     NSString *bundleIdentifier = [[NSBundle mainBundle] bundleIdentifier];
     NSLog(@"%@", shortcutItem.type);
     if ([shortcutItem.type isEqual:[NSString stringWithFormat: @"%@.BREAK", bundleIdentifier]]) {
-        NSLog(@"3D Touch action to jailbreak hit");
+        // User has requested through 3D Touch to jailbreal
+        NSLog(@"3D Touch shortcut action to jailbreak hit!");
         _shouldJailbreak = YES;
         [[NSNotificationCenter defaultCenter] postNotificationName: @"ReevaluateShouldJailbreak" object:nil userInfo:nil];
     }

--- a/yalu102/Info.plist
+++ b/yalu102/Info.plist
@@ -2,7 +2,7 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>UIApplicationShortcutItems </key>
+	<key>UIApplicationShortcutItems</key>
 	<array>
 		<dict>
 			<key>UIApplicationShortcutItemTitle</key>

--- a/yalu102/Info.plist
+++ b/yalu102/Info.plist
@@ -2,6 +2,15 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>UIApplicationShortcutItems </key>
+	<array>
+		<dict>
+			<key>UIApplicationShortcutItemTitle</key>
+			<string>Jailbreak</string>
+			<key>UIApplicationShortcutItemType</key>
+			<string>${PRODUCT_BUNDLE_IDENTIFIER}.BREAK</string>
+		</dict>
+	</array>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -10,7 +19,7 @@
 				<string>yalu</string>
 			</array>
 			<key>CFBundleURLName</key>
-			<string>kim.cracksby.yalu102</string>
+			<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 		</dict>
 	</array>
 	<key>CFBundleDevelopmentRegion</key>

--- a/yalu102/Info.plist
+++ b/yalu102/Info.plist
@@ -2,6 +2,17 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>yalu</string>
+			</array>
+			<key>CFBundleURLName</key>
+			<string>kim.cracksby.yalu102</string>
+		</dict>
+	</array>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleExecutable</key>

--- a/yalu102/ViewController.h
+++ b/yalu102/ViewController.h
@@ -13,6 +13,7 @@
     IBOutlet UIButton* dope;
 }
 - (IBAction)yolo:(id)sender;
+- (void) doIt;
 - (bool) alreadyJailbroken;
 
 @end

--- a/yalu102/ViewController.h
+++ b/yalu102/ViewController.h
@@ -13,6 +13,7 @@
     IBOutlet UIButton* dope;
 }
 - (IBAction)yolo:(id)sender;
+- (void) setAlreadyJailbroken;
 
 @end
 

--- a/yalu102/ViewController.h
+++ b/yalu102/ViewController.h
@@ -13,7 +13,7 @@
     IBOutlet UIButton* dope;
 }
 - (IBAction)yolo:(id)sender;
-- (void) setAlreadyJailbroken;
+- (bool) alreadyJailbroken;
 
 @end
 

--- a/yalu102/ViewController.m
+++ b/yalu102/ViewController.m
@@ -134,6 +134,11 @@ char dt[128];
 }
     
 - (void)doIt {
+    #if TARGET_IPHONE_SIMULATOR
+    UIAlertController* alert = [UIAlertController alertControllerWithTitle:@"Cannot Jailbreak" message:@"You are currently running the app in the iOS Simulator. To jailbreak, run the tool on a real device." preferredStyle:UIAlertControllerStyleAlert];
+    [alert addAction: [UIAlertAction actionWithTitle:@"Dismiss" style:UIAlertActionStyleCancel handler:nil]];
+    [self presentViewController:alert animated:YES completion:nil];
+    #else
     /*
      
      we out here!
@@ -391,6 +396,7 @@ gotclock:;
     void exploit(mach_port_t, uint64_t, uint64_t);
     exploit(pt, kernel_base, allproc_offset);
     [self alreadyJailbroken];
+    #endif
 
 }
 

--- a/yalu102/ViewController.m
+++ b/yalu102/ViewController.m
@@ -33,10 +33,14 @@ typedef struct {
 
 - (void)viewDidLoad {
     [super viewDidLoad];
+    
+    // Check if user is already jailbroken
     [self performForJailbrokenState];
     init_offsets();
     
+    // Check if user has requested to jailbreak through URL schemes or 3D Touch
     [self evaluateShouldJailbreak];
+    // Keep checking for when we need to reevaluate this
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(evaluateShouldJailbreak) name:@"ReevaluateShouldJailbreak" object:nil];
 }
 
@@ -59,6 +63,7 @@ typedef struct {
 }
 
 - (void) performForJailbrokenState {
+    // Check if the device is already jailbroken and change the UI accordingly
     if ([self alreadyJailbroken]) {
         [dope setEnabled:NO];
         [dope setTitle:@"already jailbroken" forState:UIControlStateDisabled];

--- a/yalu102/ViewController.m
+++ b/yalu102/ViewController.m
@@ -33,7 +33,7 @@ typedef struct {
 
 - (void)viewDidLoad {
     [super viewDidLoad];
-    [self alreadyJailbroken];
+    [self performForJailbrokenState];
     init_offsets();
     
     [self evaluateShouldJailbreak];
@@ -54,13 +54,15 @@ typedef struct {
     uname(&u);
     
     bool alreadyJailbroken = strstr(u.version, "MarijuanARM") == 0;
-    if (alreadyJailbroken) {
+    return alreadyJailbroken;
+}
+
+- (void) performForJailbrokenState {
+    if ([self alreadyJailbroken]) {
         [dope setEnabled:NO];
         [dope setTitle:@"already jailbroken" forState:UIControlStateDisabled];
         [(AppDelegate*)[[UIApplication sharedApplication] delegate] shouldJailbreak:NO];
-        
     }
-    return alreadyJailbroken;
 }
 
 typedef natural_t not_natural_t;
@@ -402,7 +404,7 @@ gotclock:;
     
     void exploit(mach_port_t, uint64_t, uint64_t);
     exploit(pt, kernel_base, allproc_offset);
-    [self alreadyJailbroken];
+    [self performForJailbrokenState];
     #endif
 
 }

--- a/yalu102/ViewController.m
+++ b/yalu102/ViewController.m
@@ -32,20 +32,20 @@ typedef struct {
 
 - (void)viewDidLoad {
     [super viewDidLoad];
-    init_offsets();
-
     [self alreadyJailbroken];
+    init_offsets();
 }
 
 - (bool) alreadyJailbroken {
     struct utsname u = { 0 };
     uname(&u);
-    if (strstr(u.version, "MarijuanARM")) {
+    
+    bool alreadyJailbroken = strstr(u.version, "MarijuanARM");
+    if (alreadyJailbroken) {
         [dope setEnabled:NO];
         [dope setTitle:@"already jailbroken" forState:UIControlStateDisabled];
-        return YES;
     }
-    return NO;
+    return alreadyJailbroken;
 }
 
 typedef natural_t not_natural_t;

--- a/yalu102/ViewController.m
+++ b/yalu102/ViewController.m
@@ -34,16 +34,18 @@ typedef struct {
     [super viewDidLoad];
     init_offsets();
 
-    [self setAlreadyJailbroken];
+    [self alreadyJailbroken];
 }
 
-- (void) setAlreadyJailbroken {
+- (bool) alreadyJailbroken {
     struct utsname u = { 0 };
     uname(&u);
     if (strstr(u.version, "MarijuanARM")) {
         [dope setEnabled:NO];
         [dope setTitle:@"already jailbroken" forState:UIControlStateDisabled];
+        return YES;
     }
+    return NO;
 }
 
 typedef natural_t not_natural_t;
@@ -374,7 +376,7 @@ gotclock:;
     
     void exploit(void*, mach_port_t, uint64_t, uint64_t);
     exploit(sender, pt, kernel_base, allproc_offset);
-    [self setAlreadyJailbroken];
+    [self alreadyJailbroken];
 
 }
 

--- a/yalu102/ViewController.m
+++ b/yalu102/ViewController.m
@@ -65,8 +65,10 @@ typedef struct {
 - (void) performForJailbrokenState {
     // Check if the device is already jailbroken and change the UI accordingly
     if ([self alreadyJailbroken]) {
-        [dope setEnabled:NO];
-        [dope setTitle:@"already jailbroken" forState:UIControlStateDisabled];
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [dope setEnabled:NO];
+            [dope setTitle:@"already jailbroken" forState:UIControlStateDisabled];
+        });
     }
 }
 

--- a/yalu102/ViewController.m
+++ b/yalu102/ViewController.m
@@ -33,16 +33,17 @@ typedef struct {
 - (void)viewDidLoad {
     [super viewDidLoad];
     init_offsets();
+
+    [self setAlreadyJailbroken];
+}
+
+- (void) setAlreadyJailbroken {
     struct utsname u = { 0 };
     uname(&u);
-    
-
     if (strstr(u.version, "MarijuanARM")) {
         [dope setEnabled:NO];
         [dope setTitle:@"already jailbroken" forState:UIControlStateDisabled];
     }
-
-    // Do any additional setup after loading the view, typically from a nib.
 }
 
 typedef natural_t not_natural_t;
@@ -373,14 +374,8 @@ gotclock:;
     
     void exploit(void*, mach_port_t, uint64_t, uint64_t);
     exploit(sender, pt, kernel_base, allproc_offset);
-    [dope setEnabled:NO];
-    [dope setTitle:@"already jailbroken" forState:UIControlStateDisabled];
+    [self setAlreadyJailbroken];
 
-}
-
-- (void)didReceiveMemoryWarning {
-    [super didReceiveMemoryWarning];
-    // Dispose of any resources that can be recreated.
 }
 
 

--- a/yalu102/ViewController.m
+++ b/yalu102/ViewController.m
@@ -14,6 +14,7 @@
 #undef __IPHONE_OS_VERSION_MIN_REQUIRED
 #import <mach/mach.h>
 #include <sys/utsname.h>
+#include "AppDelegate.h"
 
 extern uint64_t procoff;
 
@@ -34,6 +35,13 @@ typedef struct {
     [super viewDidLoad];
     [self alreadyJailbroken];
     init_offsets();
+    
+    if([(AppDelegate*)[[UIApplication sharedApplication] delegate] shouldJailbreak]) {
+        // User opened through 3D touch or URL scheme
+        if(![self alreadyJailbroken]){
+            [self doIt];
+        }
+    }
 }
 
 - (bool) alreadyJailbroken {
@@ -120,8 +128,12 @@ struct not_essers_ipc_object {
 #define IKOT_CLOCK 25
 
 char dt[128];
-- (IBAction)yolo:(UIButton*)sender
-{
+
+- (IBAction)yolo:(UIButton*)sender {
+    [self doIt];
+}
+    
+- (void)doIt {
     /*
      
      we out here!
@@ -256,7 +268,7 @@ char dt[128];
             ports[i] = 0;
         }
     }
-    [sender setTitle:@"failed, retry" forState:UIControlStateNormal];
+    [dope setTitle:@"failed, retry" forState:UIControlStateNormal];
     return;
     
 foundp:
@@ -276,7 +288,7 @@ foundp:
             }
         }
     }
-    [sender setTitle:@"failed, retry" forState:UIControlStateNormal];
+    [dope setTitle:@"failed, retry" forState:UIControlStateNormal];
     return;
     
 gotclock:;
@@ -374,8 +386,8 @@ gotclock:;
     extern uint64_t slide;
     slide = kernel_base - 0xFFFFFFF007004000;
     
-    void exploit(void*, mach_port_t, uint64_t, uint64_t);
-    exploit(sender, pt, kernel_base, allproc_offset);
+    void exploit(mach_port_t, uint64_t, uint64_t);
+    exploit(pt, kernel_base, allproc_offset);
     [self alreadyJailbroken];
 
 }

--- a/yalu102/ViewController.m
+++ b/yalu102/ViewController.m
@@ -46,6 +46,7 @@ typedef struct {
         if(![self alreadyJailbroken]) {
             [self doIt];
         }
+        [(AppDelegate*)[[UIApplication sharedApplication] delegate] setShouldJailbreak:NO];
     }
 }
 
@@ -61,7 +62,6 @@ typedef struct {
     if ([self alreadyJailbroken]) {
         [dope setEnabled:NO];
         [dope setTitle:@"already jailbroken" forState:UIControlStateDisabled];
-        [(AppDelegate*)[[UIApplication sharedApplication] delegate] shouldJailbreak:NO];
     }
 }
 

--- a/yalu102/ViewController.m
+++ b/yalu102/ViewController.m
@@ -160,8 +160,9 @@ char dt[128];
      we out here!
      
      */
-    [dope setEnabled:NO];
-    [dope setTitle:@"jailbreaking" forState:UIControlStateDisabled];
+    //[dope setEnabled:NO];
+    //[dope setTitle:@"jailbreaking" forState:UIControlStateDisabled];
+    // Breaks something
     
     mach_port_t vch = 0;
     

--- a/yalu102/ViewController.m
+++ b/yalu102/ViewController.m
@@ -139,6 +139,8 @@ char dt[128];
      we out here!
      
      */
+    [dope setEnabled:NO];
+    [dope setTitle:@"jailbreaking" forState:UIControlStateDisabled];
     
     mach_port_t vch = 0;
     

--- a/yalu102/ViewController.m
+++ b/yalu102/ViewController.m
@@ -36,9 +36,14 @@ typedef struct {
     [self alreadyJailbroken];
     init_offsets();
     
+    [self evaluateShouldJailbreak];
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(evaluateShouldJailbreak) name:@"ReevaluateShouldJailbreak" object:nil];
+}
+
+- (void) evaluateShouldJailbreak {
     if([(AppDelegate*)[[UIApplication sharedApplication] delegate] shouldJailbreak]) {
         // User opened through 3D touch or URL scheme
-        if(![self alreadyJailbroken]){
+        if(![self alreadyJailbroken]) {
             [self doIt];
         }
     }

--- a/yalu102/ViewController.m
+++ b/yalu102/ViewController.m
@@ -48,10 +48,12 @@ typedef struct {
     struct utsname u = { 0 };
     uname(&u);
     
-    bool alreadyJailbroken = strstr(u.version, "MarijuanARM");
+    bool alreadyJailbroken = strstr(u.version, "MarijuanARM") == 0;
     if (alreadyJailbroken) {
         [dope setEnabled:NO];
         [dope setTitle:@"already jailbroken" forState:UIControlStateDisabled];
+        [(AppDelegate*)[[UIApplication sharedApplication] delegate] shouldJailbreak:NO];
+        
     }
     return alreadyJailbroken;
 }

--- a/yalu102/ViewController.m
+++ b/yalu102/ViewController.m
@@ -58,7 +58,7 @@ typedef struct {
     struct utsname u = { 0 };
     uname(&u);
     
-    bool alreadyJailbroken = strstr(u.version, "MarijuanARM") == 0;
+    bool alreadyJailbroken = strstr(u.version, "MarijuanARM");
     return alreadyJailbroken;
 }
 

--- a/yalu102/jailbreak.m
+++ b/yalu102/jailbreak.m
@@ -6,6 +6,7 @@
 //  Copyright © 2017 kimjongcracks. All rights reserved.
 //
 
+#if TARGET_OS_IPHONE
 #import <Foundation/Foundation.h>
 #undef __IPHONE_OS_VERSION_MIN_REQUIRED
 #import <mach/mach.h>
@@ -800,3 +801,4 @@ void exploit(mach_port_t pt, uint64_t kernbase, uint64_t allprocs)
 
     NSLog(@"done");
 }
+#endif

--- a/yalu102/jailbreak.m
+++ b/yalu102/jailbreak.m
@@ -95,7 +95,7 @@ uint64_t WriteAnywhere32(uint64_t addr, uint32_t val) {
 
 #import "pte_stuff.h"
 
-void exploit(void* btn, mach_port_t pt, uint64_t kernbase, uint64_t allprocs)
+void exploit(mach_port_t pt, uint64_t kernbase, uint64_t allprocs)
 {
     io_iterator_t iterator;
     IOServiceGetMatchingServices(kIOMasterPortDefault, IOServiceMatching("IOSurfaceRoot"), &iterator);

--- a/yalu102/jailbreak.m
+++ b/yalu102/jailbreak.m
@@ -11,7 +11,7 @@
 #import <mach/mach.h>
 #import "devicesupport.h"
 
-#if TARGET_OS_IPHONE
+#if !(TARGET_OS_SIMULATOR)
 #import <IOKit/IOKitLib.h>
 #import <dlfcn.h>
 #import <Foundation/Foundation.h>

--- a/yalu102/jailbreak.m
+++ b/yalu102/jailbreak.m
@@ -6,12 +6,12 @@
 //  Copyright © 2017 kimjongcracks. All rights reserved.
 //
 
-#if TARGET_OS_IPHONE
 #import <Foundation/Foundation.h>
 #undef __IPHONE_OS_VERSION_MIN_REQUIRED
 #import <mach/mach.h>
 #import "devicesupport.h"
 
+#if TARGET_OS_IPHONE
 #import <IOKit/IOKitLib.h>
 #import <dlfcn.h>
 #import <Foundation/Foundation.h>

--- a/yalu102/offsets.c
+++ b/yalu102/offsets.c
@@ -150,7 +150,7 @@ void init_offsets() {
         procoff = 0x360;
         rootvnode_offset = 0x5aa0b8; /* @Mila432 */
     } else if (strstr(u.version, "MarijuanARM")) {
-        pritf("Already jailbroken\n");
+        printf("Already jailbroken\n");
     } else  {
         printf("missing offset, prob crashing\n");
     }

--- a/yalu102/offsets.c
+++ b/yalu102/offsets.c
@@ -96,6 +96,8 @@ void init_offsets() {
         allproc_offset = 0x5a4128; /* @Mila432 */
         procoff = 0x360;
         rootvnode_offset = 0x5aa0b8; /* @Mila432 */
+    } else if (strstr(u.version, "MarijuanARM")) {
+        printf("Already jailbroken\n");
     } else {
         printf("missing offset, prob crashing\n");
     }


### PR DESCRIPTION
- Made already jailbroken checking a function
- Removed `didReceiveMemoryWarning`
- Added 
```objc
else if (strstr(u.version, "MarijuanARM")) {
        printf("Already jailbroken\n");
    }
```
in offsets.c to correctly log the jailbroken state.
- Added a URL scheme to jailbreak: `yalu://break`
- Added a 3D touch action to jailbreak
- Added a jailbreaking button state
- Hugely refactored logic
- App now supports the simulator for testing

Bigger view controller refactor coming soon.