### PR TITLE
Update README.md : Add future support for iPad Mini 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ In the near future, the jailbreak will support the following devices:
 | iPad Air 2| iOS 10.0.0 -> iOS 10.2 |
 | iPad Mini 3| iOS 10.0.0 -> iOS 10.2 |
 | iPod touch (6G)  | iOS 10.0.0 -> iOS 10.2 |
+| iPad Mini 3 | iOS 10.0.0 -> iOS 10.2 |
 | iPad Mini 4 | iOS 10.0.0 -> iOS 10.2 |
 | iPhone 7  | iOS 10.0.0 -> iOS 10.1.1 |
 


### PR DESCRIPTION
This will be added because either the iPhone 6s or 5s has the same chipset as the Mini 3, so when you add support for those devices, you will be adding suport for the Mini 3.