### PR TITLE
fixing AppleWatch #115

### DIFF
--- a/yalu102/reload
+++ b/yalu102/reload
@@ -2,9 +2,11 @@
 ls /etc/rc.d | while read a; do /etc/rc.d/$a; done
 sleep 1
 launchctl unload /System/Library/LaunchDaemons
+launchctl unload /System/Library/NanoLaunchDaemons
 launchctl load /System/Library/LaunchDaemons/com.apple.logd.plist
 sleep 1
 launchctl load /Library/LaunchDaemons
 launchctl load /System/Library/LaunchDaemons
+launchctl load /System/Library/NanoLaunchDaemons
 
 exit 0


### PR DESCRIPTION
Reloading AppleWatch LaunchDaemons fixes the notification delay, the missing icons in notifications and apps installing.
