### PR TITLE
Use NSBundle to get the bundle path

### DIFF
--- a/yalu102/jailbreak.m
+++ b/yalu102/jailbreak.m
@@ -843,14 +843,9 @@ remappage[remapcnt++] = (x & (~PMK));\
     }
     
     {
-        char path[256];
-        uint32_t size = sizeof(path);
-        _NSGetExecutablePath(path, &size);
-        char* pt = realpath(path, 0);
-        
         {
             __block pid_t pd = 0;
-            NSString* execpath = [[NSString stringWithUTF8String:pt]  stringByDeletingLastPathComponent];
+            NSString* execpath = [[NSBundle mainBundle] bundlePath];
             
             
             int f = open("/.installed_yaluX", O_RDONLY);


### PR DESCRIPTION
NSBundle's bundlePath method is a 1-liner that gives the path to the bundle, rather than having to rely on _NSGetExecutablePath