### PR TITLE
Populated and used amfiops variable as is

### DIFF
--- a/yalu102/jailbreak.m
+++ b/yalu102/jailbreak.m
@@ -693,15 +693,15 @@ remappage[remapcnt++] = (x & (~PMK));\
          amfi
          */
         
-        uint64_t sbops = amfiops;
-        uint64_t sbops_end = sbops + sizeof(struct mac_policy_ops);
+        // already found amfiops above
+        uint64_t amfiops_end = amfiops + sizeof(struct mac_policy_ops) + PMK;
         
-        uint64_t nopag = sbops_end - sbops;
+        uint64_t nopag = (amfiops_end - amfiops)/(PSZ);
         
         for (int i = 0; i < nopag; i+= PSZ) {
-            RemapPage(((sbops + i) & (~PMK)));
+            RemapPage(((amfiops + i*(PSZ)) & (~PMK)));
         }
-        WriteAnywhere64(NewPointer(sbops+offsetof(struct mac_policy_ops, mpo_file_check_mmap)), 0);
+        WriteAnywhere64(NewPointer(amfiops+offsetof(struct mac_policy_ops, mpo_file_check_mmap)), 0);
     }
     
     


### PR DESCRIPTION
Variable names used before were confusing for these statements.
Populated blocks to fit memory the other way as were previously done for sbops by @kpwn