### PR TITLE
Add issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -4,7 +4,7 @@ This form is exclusively for reporting issues caused directly by the inner worki
 
 Direct your jailbreaking questions to one of these fine communities:
 
-* https://redit.com/r/jailbreak
+* https://reddit.com/r/jailbreak
 * http://www.jailbreakqa.com/
 
 Issues, which are not related to yalu's code, may be closed without comment. Do NOT post about: Cydia, tweak, respring/bootloop or app issues UNLESS you have evidence that they are caused by an error in the jailbreaking software itself.

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,10 @@
+This is not a support forum, place for discussions or a mailing list.
+
+This form is exclusively for reporting issues caused directly by the inner workings of yalu.
+
+Direct your generic questions to one of these fine communities:
+
+* https://redit.com/r/jailbreak
+* http://www.jailbreakqa.com/
+
+Issues, which are not related to yalu's code, may be closed without comment.

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,10 +1,12 @@
-This is not a support forum, place for discussions or a mailing list.
+This is not a support forum or generic mailing list.
 
 This form is exclusively for reporting issues caused directly by the inner workings of yalu.
 
-Direct your generic questions to one of these fine communities:
+Direct your jailbreaking questions to one of these fine communities:
 
 * https://redit.com/r/jailbreak
 * http://www.jailbreakqa.com/
 
-Issues, which are not related to yalu's code, may be closed without comment.
+Issues, which are not related to yalu's code, may be closed without comment. Do NOT post about: Cydia, tweak, respring/bootloop or app issues UNLESS you have evidence that they are caused by an error in the jailbreaking software itself.
+
+(Delete this bit after reading, and replace it by "I read the issue posting guidelines.")


### PR DESCRIPTION
Since people do not seem to read even the first line of the readme file, I suggest to try using an issue template instead. In future, we could let a bot account run over the issues and automatically delete those without the magic words in them.