### PR TITLE
Change Dropbear port to 2222

### DIFF
--- a/yalu102/dropbear.plist
+++ b/yalu102/dropbear.plist
@@ -12,7 +12,7 @@
 		<string>-F</string>
 		<string>-R</string>
 		<string>-p</string>
-		<string>127.0.0.1:2222</string>
+		<string>127.0.0.1:51022</string>
 	</array>
 	<key>RunAtLoad</key>
 	<true/>

--- a/yalu102/dropbear.plist
+++ b/yalu102/dropbear.plist
@@ -12,7 +12,7 @@
 		<string>-F</string>
 		<string>-R</string>
 		<string>-p</string>
-		<string>127.0.0.1:22</string>
+		<string>127.0.0.1:2222</string>
 	</array>
 	<key>RunAtLoad</key>
 	<true/>

--- a/yalu102/reload
+++ b/yalu102/reload
@@ -1,7 +1,7 @@
 #!/bin/sh
 ls /etc/rc.d | while read a; do /etc/rc.d/$a; done
 sleep 1
-launchctl unload $(ls /System/Library/LaunchDaemons/ | grep -v logd | grep -v ReportCrash | while read a; do printf /System/Library/LaunchDaemons/$a\ ; done)
+launchctl unload $(ls /System/Library/LaunchDaemons/ | grep -v logd | grep -v ReportCrash | grep -v fud | while read a; do printf /System/Library/LaunchDaemons/$a\ ; done)
 launchctl unload /System/Library/NanoLaunchDaemons
 sleep 1
 launchctl load /Library/LaunchDaemons


### PR DESCRIPTION
By using port 2222 we are able to connect to localhost with App Store SSH client app like [Blink Shell](https://itunes.apple.com/be/app/blink-shell-mosh-ssh-terminal/id1156707581?l=fr&mt=8) or [Prompt 2](https://itunes.apple.com/be/app/prompt-2/id917437289?l=fr&mt=8)