### PR TITLE
Fix Apple Lightning Digital AV Adapter (HDMI).

### DIFF
--- a/yalu102/reload
+++ b/yalu102/reload
@@ -1,7 +1,7 @@
 #!/bin/sh
 ls /etc/rc.d | while read a; do /etc/rc.d/$a; done
 sleep 1
-launchctl unload $(ls /System/Library/LaunchDaemons/ | grep -v logd | grep -v ReportCrash | while read a; do printf /System/Library/LaunchDaemons/$a\ ; done)
+launchctl unload $(ls /System/Library/LaunchDaemons/ | grep -v logd | grep -v fud | grep -v ReportCrash | while read a; do printf /System/Library/LaunchDaemons/$a\ ; done)
 launchctl unload /System/Library/NanoLaunchDaemons
 sleep 1
 launchctl load /Library/LaunchDaemons


### PR DESCRIPTION
Excluding fud (the Accessory Firmware Update/Upload daemon) is necessary to fix HDMI adapter operation after jailbreak. I am unable to confirm if this issue also affects other video adapters (e.g., VGA).

All tests done on Yalu b7 with modified reload file. Confirmed on an iTouch 6G and iPad Pro (both on iOS 10.2).

This resolves this issue: https://github.com/kpwn/yalu102/issues/204