### PR TITLE
Rework Reload Script.

### DIFF
--- a/yalu102/reload
+++ b/yalu102/reload
@@ -1,11 +1,8 @@
 #!/bin/sh
 ls /etc/rc.d | while read a; do /etc/rc.d/$a; done
 sleep 1
-launchctl unload $(ls /System/Library/LaunchDaemons/ | grep -v logd | grep -v fud | grep -v ReportCrash | while read a; do printf /System/Library/LaunchDaemons/$a\ ; done)
-launchctl unload /System/Library/NanoLaunchDaemons
-sleep 1
 launchctl load /Library/LaunchDaemons
-launchctl load /System/Library/LaunchDaemons
-launchctl load /System/Library/NanoLaunchDaemons
+sleep 1
+killall backboardd
 
 exit 0


### PR DESCRIPTION
This change should get Substrate completely working after jailbreak without the need to reload the System or Apple Watch LaunchDaemons and should have no regressions. It should also speed up the process going from tapping "go" after a reboot back to the jailbroken state since it reduces the number of daemons that need to be loaded/reloaded.

I noticed @kpwn's concern about reloading daemons in my pull request for the HDMI fix, and I thought: "What if instead of reloading so many daemons and risking breaking things, we only reloaded the daemons we really needed to reload?"

@coolstar gave me the idea for this approach. He said he had been doing something like this on iOS 9.3.3 to fix things when Substrate failed, so it should always work to get Substrate going.

I've tested this on my iPad Pro and iTouch 6G (both iOS 10.2), and Substrate is still working correctly, HDMI adapter is still working, and I have not noticed any other issues. The process of going from the unjailbroken state after reboot back to the jailbroken state is also sped up on both my devices. I don't have an Apple Watch, however, so I am unable to test that. :/

I'm making this pull request seeking additional testing (especially of Apple Watch interactions) and approval of the overall approach. I admit I do not fully understand how the exploits work, and if there is a need to unload/reload other daemons that I have not observed, I will gladly add them back. I just realized from my experiments to figure out how to fix HDMI that the basic exploit still works without reloading daemons. Thx.