### PR TITLE
Enable SSH Over WiFi

### DIFF
--- a/yalu102/dropbear.plist
+++ b/yalu102/dropbear.plist
@@ -12,7 +12,7 @@
 		<string>-F</string>
 		<string>-R</string>
 		<string>-p</string>
-		<string>127.0.0.1:22</string>
+		<string>22</string>
 	</array>
 	<key>RunAtLoad</key>
 	<true/>


### PR DESCRIPTION
Replace '127.0.0.1:22' with '22' to enable SSH over WiFi